### PR TITLE
Feature/multi paramerer syntax

### DIFF
--- a/src/syntax.rustpeg
+++ b/src/syntax.rustpeg
@@ -85,7 +85,7 @@ array -> Expression
 
 function -> Expression
   = param:identifier _ "->" e:assign { Expression::Function(param.to_string(), Box::new(e)) }
-  / "(" params:(identifier ++ ",") _ ")" _ "->" e:assign { params.iter().rev().fold(e, |e, p| Expression::Function(p.to_string(), Box::new(e))) }
+  / "(" _ params:(identifier ++ (_ "," _)) ")" _ "->" e:assign { params.iter().rev().fold(e, |e, p| Expression::Function(p.to_string(), Box::new(e))) }
 
 type_ -> Expression
   = "<" e:(type_elem  ++ "|") ">" { Expression::Type(e) }

--- a/src/syntax.rustpeg
+++ b/src/syntax.rustpeg
@@ -44,10 +44,10 @@ index_right -> Expression
   = _ "[" r:expression "]" { r }
 
 apply -> Expression
-  = l:spaced_atom r:apply_right * _ { r.iter().fold(l, |e, r| Expression::Apply(box e, box r.clone())) }
+  = l:spaced_atom r:apply_multi_right * _ { r.iter().flatten().fold(l, |e, r| Expression::Apply(box e, box r.clone())) }
 
-apply_right -> Expression
-  = _ "(" r:expression ")" { r }
+apply_multi_right -> Vec<Expression>
+  = _ "(" _ r:(expression ++ (_ "," _)) ")" { r }
 
 if_else -> Expression
   = "if" cond:expression then_expr:expression else_expr:("else" v:spaced_atom {v})? { Expression::IfElse(Box::new(cond), Box::new(then_expr), Box::new(else_expr.unwrap_or(Expression::Empty))) }

--- a/src/syntax.rustpeg
+++ b/src/syntax.rustpeg
@@ -85,6 +85,7 @@ array -> Expression
 
 function -> Expression
   = param:identifier _ "->" e:assign { Expression::Function(param.to_string(), Box::new(e)) }
+  / "(" params:(identifier ++ ",") _ ")" _ "->" e:assign { params.iter().rev().fold(e, |e, p| Expression::Function(p.to_string(), Box::new(e))) }
 
 type_ -> Expression
   = "<" e:(type_elem  ++ "|") ">" { Expression::Type(e) }


### PR DESCRIPTION
カリー化になった

```
let add = (a, b, c, d) -> a + b + c + d;
let add3 = add(1, 2);
add3(10, 40)  // evalto 53
```
